### PR TITLE
chore(renovate): enable dependency dashboard, labels, and semantic commits

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,6 +1,7 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": [
-    "config:recommended"
-  ]
+  "dependencyDashboard": true,
+  "extends": ["config:recommended"],
+  "labels": ["internal"],
+  "semanticCommits": "enabled"
 }

--- a/src/fastui_admin/views.py
+++ b/src/fastui_admin/views.py
@@ -84,7 +84,7 @@ class AdminIndexView(BaseView):
 
     async def render(self, request: Request) -> list[c.AnyComponent]:  # noqa: ARG002
         """Render dashboard with welcome message and links to model views."""
-        model_links = []
+        model_links: list[c.AnyComponent] = []
         for view in self._admin.views:
             if view.is_visible and view != self and isinstance(view, BaseModelView):
                 url = self._admin.get_relative_url(view.get_url())


### PR DESCRIPTION
## Summary

Tweaks the Renovate configuration:

- Enable the **dependency dashboard** for an at-a-glance view of pending updates
- Apply the `internal` **label** to Renovate PRs
- Enable **semantic commits** so Renovate follows Conventional Commits

## Test plan

- [ ] Renovate validates the config on its next run

## Summary by Sourcery

Update Renovate configuration to improve visibility and standardization of automated dependency updates.

Build:
- Configure Renovate to enable the dependency dashboard for tracking pending updates.
- Apply a standard internal label to Renovate-generated pull requests.
- Enable semantic (Conventional) commit messages for Renovate updates.